### PR TITLE
Issues/2/rules dir does not work

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ It may be implemented by adding the following rule configuration:
 
 ## Configuration
 
-1. Add `node_modules/tslint-forbidden-imports` to `rulesDirectory` parameter of your `tslint.json`.
+1. Add `node_modules/tslint-forbidden-imports/rules` to `rulesDirectory` parameter of your `tslint.json`.
 2. Enable rule `forbidden-imports` and pass mapping `"file pattern"` -> `["fordidden import patterns"...]` 
 
 The pattern syntax may use any features supported by [micromatch](https://github.com/micromatch/micromatch#matching-features).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-forbidden-imports",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "TSLint plugin to limit certain types of imports (configured using GLOB patterns)",
   "keywords": [
     "tslint",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     ],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "outDir": "dist"
+    "outDir": "rules"
   },
   "include": [
     "src"

--- a/tslint.json
+++ b/tslint.json
@@ -114,7 +114,7 @@
     ]
   },
   "rulesDirectory": [
-    "dist",
+    "rules",
     "node_modules/tslint-microsoft-contrib"
   ]
 }


### PR DESCRIPTION
Mostly documentation fix.
Renamed output directory to `rules` to make it look nicer.